### PR TITLE
Added settings files htmlhintrc and xmlhintrc as project alias

### DIFF
--- a/main.js
+++ b/main.js
@@ -153,6 +153,8 @@ define(function(require, exports, module) {
 	addAlias('jscsrc', 'project');
 	addAlias('jshintrc', 'project');
 	addAlias('csslintrc', 'project');
+	addAlias('htmlhintrc', 'project');
+	addAlias('xmlhintrc', 'project');
 	addAlias('todo', 'project');
 	addAlias('classpath', 'project');
 	addAlias('properties', 'project');

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-define(function(require, exports, module) {
+define(function (require, exports, module) {
 	var fileInfo = {};
 
 	function addIcon(extension, icon, color, size) {
@@ -64,17 +64,17 @@ define(function(require, exports, module) {
 	addAlias('class', 'java');
 	addIcon('scala',  'ion-navicon-round file-icon-rotated', '#72d0eb');
 	addIcon('groovy', 'ion-ios-star', '#4298b8');
-	
+
 	// Lua
 	addIcon('lua',    'ion-record', '#00207d', 14);
-	
+
 	// Clojure
 	addIcon('clj',    'ion-aperture', '#63b132');
-	
+
 	// Visual Basic
 	addIcon('vb',     'ion-ios-infinite', '#486dae');
 	addIcon('vbs',    'ion-ios-infinite', '#3d047e');
-	
+
 	// C-family
 	addIcon('hx',     'file-icon-c', '#ea8220', 13);
 	addIcon('pl',     'file-icon-c', '#a4c5eb', 13);
@@ -172,26 +172,26 @@ define(function(require, exports, module) {
 	addAlias('yaml', 'yml');
 	addIcon('sqf',   'ion-wand', '#b9e11f');
 
-	var ExtensionUtils = brackets.getModule("utils/ExtensionUtils");
+	var ExtensionUtils = brackets.getModule('utils/ExtensionUtils');
 
-	var FileTreeView = brackets.getModule("project/FileTreeView");
+	var FileTreeView = brackets.getModule('project/FileTreeView');
 	var WorkingSetView = brackets.getModule('project/WorkingSetView');
-    
-    // Before Brackets 1.1.0, icons had a hack that the margin was set to -10000px, which was corrected by the padding.
-    // This was removed in Brackets 1.1.0
-    var version = /([0-9]+)\.([0-9]+)\.([0-9]+)/.exec(brackets.metadata.version);
-    if ((version[1] === "0") || (version[1] === "1" && version[2] === "0")) { // version[1] is major, version[2] is minor
-        $('body').addClass('icons-margin-correction');
-    }
 
-	ExtensionUtils.loadStyleSheet(module, "styles/style.css");
-	ExtensionUtils.loadStyleSheet(module, "styles/ionicons.min.css");
-	
-	var provider = function(entry) {
+	// Before Brackets 1.1.0, icons had a hack that the margin was set to -10000px, which was corrected by the padding.
+	// This was removed in Brackets 1.1.0
+	var version = /([0-9]+)\.([0-9]+)\.([0-9]+)/.exec(brackets.metadata.version);
+	if ((version[1] === '0') || (version[1] === '1' && version[2] === '0')) { // version[1] is major, version[2] is minor
+		$('body').addClass('icons-margin-correction');
+	}
+
+	ExtensionUtils.loadStyleSheet(module, 'styles/style.css');
+	ExtensionUtils.loadStyleSheet(module, 'styles/ionicons.min.css');
+
+	var provider = function (entry) {
 		if (!entry.isFile) {
 			return;
 		}
-		
+
 		var ext = entry.name;
 		var lastIndex = ext.lastIndexOf('.');
 		if (lastIndex >= 0) {
@@ -199,7 +199,7 @@ define(function(require, exports, module) {
 		} else {
 			ext = '';
 		}
-		
+
 		var data = fileInfo.hasOwnProperty(ext) ? fileInfo[ext] : getDefaultIcon(ext);
 
 		var $new = $('<ins>');
@@ -211,7 +211,7 @@ define(function(require, exports, module) {
 		});
 		return $new;
 	};
-	
+
 	FileTreeView.addIconProvider(provider);
 	WorkingSetView.addIconProvider(provider);
 });

--- a/package.json
+++ b/package.json
@@ -6,11 +6,10 @@
     "version": "1.3.0",
     "author": "Ivo Gabe de Wolff (https://github.com/ivogabe)",
     "license": "MIT",
-
     "keywords": [
-		"icons",
-		"file",
-		"tree"
+        "icons",
+        "file",
+        "tree"
     ],
     "engines": {
         "brackets": ">=0.44.0"

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ The following files are supported at the moment:
  - HTAccess, HTPasswd, Conf
  - YAML
  - Sqf
- - Project, Jscsrc, Jshintrc, Csslintrc, Todo, Classpath, Properties
+ - Project, Jscsrc, Jshintrc, Csslintrc, Htmlhintrc, Xmlhintrc, Todo, Classpath, Properties
  - Zip, Rar, 7z, Tgz, Tar, Gz, Bzip, Msi, Dmg
 
 You can request more file formats by creating an issue. Choose the icon [here](http://ionicons.com) and add a color (in hex format) to the issue.

--- a/styles/style.css
+++ b/styles/style.css
@@ -14,7 +14,7 @@
 	padding-left: 9px;
 }
 .icons-margin-correction #project-files-container a {
-    padding-left: 10009px;
+	padding-left: 10009px;
 }
 
 .file-icon-c:before {


### PR DESCRIPTION
Add icons to `.htmlhintrc` and `.xmlhintrc` files which are used by [brackets-htmlhint](https://github.com/cfjedimaster/brackets-htmlhint).

I have also unified the whitespace and quote marks in the code, but did it in a separate commit so feel free to ignore it if you don't like my codestyle. :wink: