### PR TITLE
Update the Gulp file

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,9 +10,10 @@ gulp.task('scripts', function() {
 		.pipe(gulp.dest('dist'));
 });
 
-gulp.task('archive', function() {
+gulp.task('archive', ['scripts'], function() {
+
 	return gulp.src([
-			'dist/**/*',
+			'dist/*.js',
 			'fonts/**/*',
 			'*.md',
 			'package.json',
@@ -23,4 +24,4 @@ gulp.task('archive', function() {
 		.pipe(gulp.dest('dist'));
 });
 
-gulp.task('default', ['zip']);
+gulp.task('default', ['archive']);


### PR DESCRIPTION
This change stops the archive task from zipping up previous zip builds in the dist dir. It also make the default task do a full transpile and zip. Previously the name of the zip task was mismatched.