### PR TITLE
Upper case G for Gruntfile

### DIFF
--- a/lib/presets.ts
+++ b/lib/presets.ts
@@ -557,7 +557,7 @@ export function setFileNames(set: RegisterFileNameIcon) {
 		[IconSet.IconIon]: 'ion-hammer',
 		[IconSet.IconDev]: 'devicons devicons-gulp'
 	});
-	set('gruntfile', ['js'], {
+	set('Gruntfile', ['js', 'coffee'], {
 		[IconSet.ColorLight]: '#fba919',
 		[IconSet.IconIon]: 'ion-hammer',
 		[IconSet.IconDev]: 'devicons devicons-grunt'


### PR DESCRIPTION
According to the [Grunt docs](http://gruntjs.com/getting-started#preparing-a-new-grunt-project), the file name should start with an uppercase G and can also be a CoffeeScript file.