### PR TITLE
Add .jsx (React) to the presets

### DIFF
--- a/lib/presets.ts
+++ b/lib/presets.ts
@@ -58,6 +58,11 @@ export function setExtensions(set: RegisterIcon) {
 		[IconSet.IconIon]: ['file-icon-c', 13],
 		[IconSet.IconDev]: 'devicons devicons-javascript'
 	});
+    set('jsx', {
+		[IconSet.ColorLight]: '#f8c63d',
+		[IconSet.IconIon]: ['file-icon-c', 13],
+		[IconSet.IconDev]: 'devicons devicons-javascript'
+	});
 	set('es6', {
 		[IconSet.ColorLight]: '#4321a9',
 		[IconSet.IconIon]: ['file-icon-c', 13],


### PR DESCRIPTION
This PR adds [.jsx](https://facebook.github.io/react/docs/jsx-in-depth.html), extension commonly used with React-files to the presets. 